### PR TITLE
Implement yaml frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,24 @@ run the docker image
 
 # Optional settings
 Inside the script you can make some adjustments to the link format and notes metadata:  
-`links_as_URI` - `True` for `file://link%20target` style links, `False` for `/link target` style links;  
-`absolute_links` - `True` for absolute links, `False` for relative links;  
-`media_dir_name` - name of the directory inside the produced directory where all images and attachments will be stored;   
-`md_file_ext` - extension for produced markdown syntax note files;  
+Select meta data options:
+`meta_data_in_yaml` - `True`  YAML block the following meta data that are set True, `False` meta data will be in text;  
 `insert_title` - `True` to insert note title as a markdown heading at the first line, `False` to disable;  
 `insert_ctime` - `True` to insert note creation time to the beginning of the note text, `False` to disable;  
 `insert_mtime` - `True` to insert note modification time to the beginning of the note text, `False` to disable;  
-`creation_date_in_filename` - `True` to insert note creation time to the note file name, `False` to disable;  
+`tags` -  `True` to insert list of tags, `False` to disable;  
 `tag_prepend` - string to prepend each tag in a tag list inside the note, default is empty;  
 `tag_delimiter` - string to delimit tags, default is comma separated list;  
 `no_spaces_in_tags` - `True` to replace spaces in tag names with '_', `False` to keep spaces.
 
-An optional YAML header can be added to store metadata using the following options:    
-`yaml_front_matter` - `True` will insert an empty YAML block at the top of the document, `False` no block;  
-`yaml_insert_title` - `True` will add the title of the note as a field in the YAML block, `False` no title in block;  
-`yaml_insert_ctime` - `True` to insert note creation time in the YAML block, `False` to disable;  
-`yaml_insert_mtime` - `True` to insert note modification time in the YAML block, `False` to disable;  
-`yaml_tags` -  `True` to insert an array of tags, `False` to disable;  
-`yaml_tag_prepend` - string to prepend each tag in a tag list, default is empty;  
-`yaml_no_spaces_in_tags` - `True` to replace spaces in tag names with '_', `False` to keep spaces.
+Select file link options:
+`links_as_URI` - `True` for `file://link%20target` style links, `False` for `/link target` style links;  
+`absolute_links` - `True` for absolute links, `False` for relative links;  
+
+Select File/Attachments/Media options:
+`media_dir_name` - name of the directory inside the produced directory where all images and attachments will be stored;   
+`md_file_ext` - extension for produced markdown syntax note files;  
+`creation_date_in_filename` - `True` to insert note creation time to the note file name, `False` to disable;
 
 # For [QOwnNotes](https://github.com/pbek/QOwnNotes) users
 There are several ways to get tags from converted notes to work in QOwnNotes:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Inside the script you can make some adjustments to the link format and notes met
 `tag_delimiter` - string to delimit tags, default is comma separated list;  
 `no_spaces_in_tags` - `True` to replace spaces in tag names with '_', `False` to keep spaces.
 
+An optional YAML header can be added to store metadata using the following options:    
+`yaml_front_matter` - `True` will insert an empty YAML block at the top of the document, `False` no block;  
+`yaml_insert_title` - `True` will add the title of the note as a field in the YAML block, `False` no title in block;  
+`yaml_insert_ctime` - `True` to insert note creation time in the YAML block, `False` to disable;  
+`yaml_insert_mtime` - `True` to insert note modification time in the YAML block, `False` to disable;  
+`yaml_tags` -  `True` to insert an array of tags, `False` to disable;  
+`yaml_tag_prepend` - string to prepend each tag in a tag list, default is empty;  
+`yaml_no_spaces_in_tags` - `True` to replace spaces in tag names with '_', `False` to keep spaces.
+
 # For [QOwnNotes](https://github.com/pbek/QOwnNotes) users
 There are several ways to get tags from converted notes to work in QOwnNotes:
 

--- a/nsx2md.py
+++ b/nsx2md.py
@@ -81,7 +81,7 @@ def create_yaml_block():
 
 
 
-work_path = Path.joinpath(Path.cwd(), "notes")
+work_path = Path.cwd()
 media_dir_name = sanitise_path_string(media_dir_name)
 pandoc_input_file = tempfile.NamedTemporaryFile(delete=False)
 pandoc_output_file = tempfile.NamedTemporaryFile(delete=False)

--- a/nsx2md.py
+++ b/nsx2md.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 # You can adjust some setting here. Default is for QOwnNotes app.
-yaml_front_matter = True  # True will insert an empty YAML block at the top of the document, False no block and the other YAML settings are not used.
+yaml_front_matter = False  # True will insert an empty YAML block at the top of the document, False no block and the other YAML settings are not used.
 yaml_insert_title = True  # True will add the title of the note as a field in the YAML block, False no title in block.
 yaml_insert_ctime = True  # True to insert note creation time in the YAML block, False to disable.
 yaml_insert_mtime = True  # True to insert note modification time in the YAML block, False to disable.

--- a/nsx2md.py
+++ b/nsx2md.py
@@ -25,8 +25,8 @@ yaml_tags = True  #  True to insert an array of tags, False to disable
 yaml_tag_prepend = ''  # string to prepend each tag in a tag list inside the note, default is empty.  Note some md software do not require a symbol such as a hash in the yaml but do in the md text.
 yaml_no_spaces_in_tags = True  # True to replace spaces in tag names with '_', False to keep spaces.  Note some md software can accept spaces in tag names in YAML but not in the md text.
 
-links_as_URI = True  # True for file://link%20target style links, False for /link target style links
-absolute_links = False  # True for absolute links, False for relative links
+links_as_URI = False  # True for file://link%20target style links, False for /link target style links
+absolute_links = True  # True for absolute links, False for relative links
 media_dir_name = 'media'  # name of the directory inside the produced directory where all images and attachments will be stored
 md_file_ext = 'md'  # extension for produced markdown syntax note files
 insert_title = True  # True to insert note title as a markdown heading at the first line, False to disable

--- a/nsx2md.py
+++ b/nsx2md.py
@@ -18,26 +18,24 @@ from pathlib import Path
 
 
 # You can adjust some setting here. Default is for QOwnNotes app.
-yaml_front_matter = False  # True will insert an empty YAML block at the top of the document, False no block and the other YAML settings are not used.
-yaml_insert_title = True  # True will add the title of the note as a field in the YAML block, False no title in block.
-yaml_insert_ctime = True  # True to insert note creation time in the YAML block, False to disable.
-yaml_insert_mtime = True  # True to insert note modification time in the YAML block, False to disable.
-yaml_tags = True  #  True to insert an array of tags, False to disable
-yaml_tag_prepend = ''  # string to prepend each tag in a tag list inside the note, default is empty.  Note some md software do not require a symbol such as a hash in the yaml but do in the md text.
-yaml_no_spaces_in_tags = True  # True to replace spaces in tag names with '_', False to keep spaces.  Note some md software can accept spaces in tag names in YAML but not in the md text.
-
-links_as_URI = False  # True for file://link%20target style links, False for /link target style links
-absolute_links = True  # True for absolute links, False for relative links
-media_dir_name = 'media'  # name of the directory inside the produced directory where all images and attachments will be stored
-md_file_ext = 'md'  # extension for produced markdown syntax note files
-insert_title = True  # True to insert note title as a markdown heading at the first line, False to disable
-insert_ctime = False  # True to insert note creation time to the beginning of the note text, False to disable
-insert_mtime = False  # True to insert note modification time to the beginning of the note text, False to disable
-creation_date_in_filename = False  # True to insert note creation time to the note file name, False to disable
-
+#  Select meta data options
+meta_data_in_yaml = False  # True a YAML front matter block will contain the following meta data items.  # False any selected meta data options below will be in the md text
+insert_title = True  # True will add the title of the note as a field in the YAML block, False no title in block.
+insert_ctime = False  # True to insert note creation time in the YAML block, False to disable.
+insert_mtime = False  # True to insert note modification time in the YAML block, False to disable.
+tags = True  # True to insert list of tags, False to disable
 tag_prepend = ''  # string to prepend each tag in a tag list inside the note, default is empty
 tag_delimiter = ', '  # string to delimit tags, default is comma separated list
 no_spaces_in_tags = False  # True to replace spaces in tag names with '_', False to keep spaces
+
+#Select file link options
+links_as_URI = True  # True for file://link%20target style links, False for /link target style links
+absolute_links = False  # True for absolute links, False for relative links
+
+# Select File/Attachments/Media options
+media_dir_name = 'media'  # name of the directory inside the produced directory where all images and attachments will be stored
+md_file_ext = 'md'  # extension for produced markdown syntax note files
+creation_date_in_filename = False  # True to insert note creation time to the note file name, False to disable.
 
 ############################################################################
 
@@ -60,27 +58,26 @@ def sanitise_path_string(path_str):
 def create_yaml_block():
     yaml_block = '---\n'
 
-    if yaml_insert_title:
+    if insert_title:
         yaml_block = '{}Title: "{}"\n'.format(yaml_block, note_title)
 
-    if yaml_insert_ctime and note_ctime:
+    if insert_ctime and note_ctime:
         yaml_text_ctime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_ctime))
         yaml_block = '{}Created: "{}"\n'.format(yaml_block, yaml_text_ctime)
 
-    if yaml_insert_mtime and note_mtime:
+    if insert_mtime and note_mtime:
         yaml_text_mtime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_mtime))
         yaml_block = '{}Modified: "{}"\n'.format(yaml_block, yaml_text_mtime)
 
-    if yaml_tags and note_data.get('tag', ''):
-        if yaml_no_spaces_in_tags:
+    if tags and note_data.get('tag', ''):
+        if no_spaces_in_tags:
             note_data['tag'] = [tag.replace(' ', '_') for tag in note_data['tag']]
-        yaml_tag_list = tag_delimiter.join(''.join((yaml_tag_prepend, tag)) for tag in note_data['tag'])
+        yaml_tag_list = tag_delimiter.join(''.join((tag_prepend, tag)) for tag in note_data['tag'])
         yaml_block = '{}Tags: [{}]\n'.format(yaml_block, yaml_tag_list)
 
     yaml_block = '{}---\n'.format(yaml_block)
 
     return yaml_block
-
 
 
 work_path = Path.cwd()
@@ -241,27 +238,34 @@ for file in files_to_convert:
                 or insert_ctime or insert_mtime:
             content = '\n' + content
 
-        if insert_mtime and note_mtime:
-            text_mtime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_mtime))
-            content = 'Modified: {}  \n{}'.format(text_mtime, content)
-        if insert_ctime and note_ctime:
-            text_ctime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_ctime))
-            content = 'Created: {}  \n{}'.format(text_ctime, content)
-        if attachment_list:
-            content = 'Attachments: {}  \n{}'.format(', '.join(attachment_list), content)
-        if note_data.get('tag', ''):
-            if no_spaces_in_tags:
-                note_data['tag'] = [tag.replace(' ', '_') for tag in note_data['tag']]
-            tag_list = tag_delimiter.join(''.join((tag_prepend, tag)) for tag in note_data['tag'])
-            content = 'Tags: {}  \n{}'.format(tag_list, content)
-        if insert_title:
-            content = '{}\n{}\n{}'.format(note_title, '=' * len(note_title), content)
+
+        if not meta_data_in_yaml:
+            if insert_mtime and note_mtime:
+                text_mtime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_mtime))
+                content = 'Modified: {}  \n{}'.format(text_mtime, content)
+            if insert_ctime and note_ctime:
+                text_ctime = time.strftime('%Y-%m-%d %H:%M', time.localtime(note_ctime))
+                content = 'Created: {}  \n{}'.format(text_ctime, content)
+            if attachment_list:
+                content = 'Attachments: {}  \n{}'.format(', '.join(attachment_list), content)
+            if note_data.get('tag', '') and tags:
+                if no_spaces_in_tags:
+                    note_data['tag'] = [tag.replace(' ', '_') for tag in note_data['tag']]
+                tag_list = tag_delimiter.join(''.join((tag_prepend, tag)) for tag in note_data['tag'])
+                content = 'Tags: {}  \n{}'.format(tag_list, content)
+            if insert_title:
+                content = '{}\n{}\n{}'.format(note_title, '=' * len(note_title), content)
+
+        if meta_data_in_yaml:
+            if attachment_list:
+                content = '{}\nAttachments:  {}\n{}'.format(create_yaml_block(), ', '.join(attachment_list), content)
+            else:
+                content = '{}\n{}'.format(create_yaml_block(), content)
 
         if creation_date_in_filename and note_ctime:
             note_title = time.strftime('%Y-%m-%d ', time.localtime(note_ctime)) + note_title
 
-        if yaml_front_matter:
-            content = '{}\n{}'.format(create_yaml_block(), content)
+
 
         md_file_name = sanitise_path_string(note_title) or 'Untitled'
         md_file_path = Path(parent_notebook.path / '{}.{}'.format(md_file_name, md_file_ext))


### PR DESCRIPTION
Hi,

Love your script.  Useful, simple, worked perfectly from what I have seen by a quick look at some of the 500+ notes it just converted.  I wish it was this easy to get my other notes out of OneNote!  I've recently swapped over to Obsidian and there is a growing community there looking for ways to extract their notes into markdown, I'll put a post on their forum about this script.

Can you please review this pull request?  I have implemented the addition of a YAML header as an option.  Many of the latest generations of md readers and systems like Obsidian and Typora allow the use of YAML headers for 'front matter' in markdown.  This lets you tidy away information that is not key to the core of the note/document.

I also tweaked a couple of typos in the comments (my IDE has a spell checker else I would never have noticed)

I'll be passing a couple of smaller changes in the next day or so.

Thanks for the script and thanks for having a look at this request

Kevin
