### PR TITLE
Fix special character problem identified by christian0903  - fixes issue #22

### DIFF
--- a/nsx2md.py
+++ b/nsx2md.py
@@ -12,12 +12,13 @@ import subprocess
 import collections
 import urllib.request
 import distutils.version
+from urllib.parse import unquote
 
 from pathlib import Path
 
 
 # You can adjust some setting here. Default is for QOwnNotes app.
-links_as_URI = True  # True for file://link%20target style links, False for /link target style links
+links_as_URI = False  # True for file://link%20target style links, False for /link target style links
 absolute_links = False  # True for absolute links, False for relative links
 media_dir_name = 'media'  # name of the directory inside the produced directory where all images and attachments will be stored
 md_file_ext = 'md'  # extension for produced markdown syntax note files
@@ -43,6 +44,7 @@ def sanitise_path_string(path_str):
     path_str = path_str.replace('<', '(')
     path_str = path_str.replace('>', ')')
     path_str = path_str.replace('"', "'")
+    path_str = urllib.parse.unquote(path_str)
 
     return path_str[:240]
 

--- a/nsx2md.py
+++ b/nsx2md.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 
 # You can adjust some setting here. Default is for QOwnNotes app.
-links_as_URI = False  # True for file://link%20target style links, False for /link target style links
+links_as_URI = True  # True for file://link%20target style links, False for /link target style links
 absolute_links = False  # True for absolute links, False for relative links
 media_dir_name = 'media'  # name of the directory inside the produced directory where all images and attachments will be stored
 md_file_ext = 'md'  # extension for produced markdown syntax note files


### PR DESCRIPTION
Hi, 

I was dabbling in the code so I took a peek at what was causing Christian's problem.  

So...Solve issue where a file attachment name is already converted for special characters inside of the note and was being converted again resulting in more special character replacements leading to file name not matching link in the md file.    

The following explanation is here for any people looking to learn in the future so they can see and understand what caused the problem and how it could be addressed.

### Detailed Explanation
File name in the note data is ```5-petit-de%CC%81jeuner.png``` but when it comes out of this:-
```python
link_path = 'file://{}/{}'.format(urllib.request.pathname2url(media\_dir\_name),urllib.request.pathname2url(name))
```
 it has become ```file://media/5-petit-de%25CC%2581jeuner.png```

```5-petit-de%CC%81jeuner.png``` is already encoded for url, and it becomes double converted in ```.pathname2url()```

it can be put back to 'actual' text using:-
```python
string = "5-petit-de%CC%81jeuner.png"  
print(urllib.parse.unquote(string))
```
which gives the 'real name'
```5-petit-déjeuner.png```

so solution is to add 
```python
path_str = urllib.parse.unquote(path_str)
```
to the path sanitising function

Now -
- ```5-petit-de%CC%81jeuner.png```. goes in and 
- a file named ```5-petit-déjeuner.png``` goes to the ```media``` folder
- and the link in the md is ```![](media/5-petit-déjeuner.png)```


